### PR TITLE
Remove Upload Test Results Build Step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,15 +101,6 @@ stages:
         - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
           displayName: Build and Publish
         - task: PublishBuildArtifacts@1
-          displayName: Upload TestResults
-          condition: always()
-          continueOnError: true
-          inputs:
-            pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-            artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-            artifactType: Container
-            parallel: true
-        - task: PublishBuildArtifacts@1
           displayName: Upload package artifacts
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
           inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
+      enablePublishTestResults: false
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       enableTelemetry: true
       helixRepo: dotnet/blazor


### PR DESCRIPTION
Goal being to remove the path not found warning in AZDO CI.
https://github.com/dotnet/aspnetcore/pull/23046#issuecomment-646364845

The CI now reports a successful (green) status:
![image](https://user-images.githubusercontent.com/14852843/85089730-3a54c200-b198-11ea-842f-f34e4ac7c510.png)


Note the following warning for no `.xml` files found in the test upload step is now shown.
https://dev.azure.com/dnceng/public/_build/results?buildId=695273&view=logs&j=0bc77094-9fcd-5c38-f6e4-27d2ae131589&t=06f525b6-1103-55ff-8b74-f96f9e995ef4&l=11
